### PR TITLE
Updates to support Obsidian v1.0.x

### DIFF
--- a/MCL Gallery Cards.css
+++ b/MCL Gallery Cards.css
@@ -1,6 +1,8 @@
 /* === README ===
-	Author: Faiz Khuzaimah / twitter: @faizkhuzaimah / github: https://github.com/efemkay
-	Updated: 2022-09-17 (version: 0.5.0)
+	Snippet: MCL Gallery Cards / Author: Faiz Khuzaimah / twitter: @faizkhuzaimah / github: https://github.com/efemkay
+	Version 0.6.2 (updated 2022-10-22)
+	- rollover main branch to support Obsidian 1.0.0
+	Version 0.5.0 (updated 2022-09-17)
 	- added mermaid scale and zoom feature. FR #19 on GH.
 	version 0.3.1 (2022-06-26)
 	- fix table mis-formatting

--- a/MCL Multi Column.css
+++ b/MCL Multi Column.css
@@ -1,13 +1,9 @@
 /* === README ===
-	Author: Faiz Khuzaimah / twitter: @faizkhuzaimah / github: https://github.com/efemkay
+	Snippet: MCL Multi Column / Author: Faiz Khuzaimah / twitter: @faizkhuzaimah / github: https://github.com/efemkay
+	Version 0.6.2 (updated 2022-10-22)
+	- rollover main branch to support Obsidian 1.0.0
 	Version 0.6.1 (updated 2022-10-02). Version number follow overall MCL
 	- fix for footnote with -column-list-block created a <br> tag
-	Version 0.6.0 (updated 2022-09-25)
-	- partial fix for obsidian v 0.16.x
-	Version 0.4.2 (2022-07-14)
-	- fix for callout width become full-width even without Wide Views module
-	- fix issue #17 (dataview list width too wide, forcing it almost like single column)
-	- added width control for sub-callouts within multi-column callout
 
 	What is this snippet for?
 	- to allow Obsidian users to change the layout with preset css by just specifying

--- a/MCL Multi Column.css
+++ b/MCL Multi Column.css
@@ -1,6 +1,8 @@
 /* === README ===
 	Author: Faiz Khuzaimah / twitter: @faizkhuzaimah / github: https://github.com/efemkay
-	Updated: 2022-07-14 (version: 0.4.2)
+	Version: 0.6.0 (updated 2022-09-25). Version number follow overall MCL
+	- partial fix for obsidian v 0.16.x
+	Version 0.4.2 (2022-07-14)
 	- fix for callout width become full-width even without Wide Views module
 	- fix issue #17 (dataview list width too wide, forcing it almost like single column)
 	- added width control for sub-callouts within multi-column callout
@@ -150,8 +152,9 @@ body{
 	div[data-callout="multi-column"].callout > .callout-title { display: none; }
 	div[data-callout="multi-column"].callout > .callout-content { display: contents; }
 	/* make the main callout a flex and remove box formatting */
+	/* --columns: unset to undo Sanctum's mod */
 	div[data-callout="multi-column"].callout
-		{ display: flex; flex-wrap: wrap; gap: var(--callout-gap); background: unset; border: unset; margin: unset; padding: unset; clear: both; }
+		{ display: flex; flex-wrap: wrap; gap: var(--callout-gap); background: unset; border: unset; margin: unset; padding: unset; clear: both; --columns: unset;}
 	/* make the subcallout in flex column to allow growing vertically */
 	div[data-callout="multi-column"].callout .callout { display: flex; flex-direction: column; }
 	div[data-callout="multi-column"].callout:not(.is-collapsed) .callout { margin: 0 var(--callout-margin) var(--callout-margin); } /* to allow spacing for box shadow */
@@ -169,32 +172,38 @@ body{
 
 	@media (min-width: 500px) {
 		/* .is-collapsed is used to draw the border-left only when it's collapsed */
-		div[data-callout="multi-column"].callout > div.callout-content .callout.is-collapsed { background-color: unset; border: unset; box-shadow: unset;}
-		div[data-callout="multi-column"].callout > div.callout-content .callout.is-collapsed .callout-title { border-left: 4px solid rgba(var(--callout-color)); border-top-left-radius: 3px;}
- 	}
+		/* adjusted for Obsidian 0.16.x, removed a number of previous adjustment as no longer required */
+		div[data-callout="multi-column"].callout > div.callout-content .callout.is-collapsed { box-shadow: unset; height: min-content;}
+	}
 
 	 /* Special Adjustment -- for theme with negative margin & box shadow. (e.g. Prism) */
 	div[data-callout="multi-column"].callout > .callout-content { margin-top: unset;}
 	div[data-callout="multi-column"].callout:not(.is-collapsed) { box-shadow: unset;}
-	/* Special Adjustment -- for minimal left margin */
-/*	.markdown-source-view.mod-cm6.is-readable-line-width .cm-embed-block.cm-callout > div[data-callout="multi-column"].callout
+
+	/* Special Adjustment -- for Sanctum because it has "column" callout, Obsidian v0.16.x. Not required for multi-flex as it Sanctum expects the name ends with *=column */
+	.callout[data-callout*=column] .callout-title { display: flex; }
+	.callout[data-callout*=column] .callout-content { display: unset; }
+
+	/* Special Adjustment -- for minimal left margin *//*
+	.markdown-source-view.mod-cm6.is-readable-line-width .cm-embed-block.cm-callout > div[data-callout="multi-column"].callout
 		{ width: 100%; max-width: 100%; margin-inline: 0 !important; }
 	/* Special Adjustment -- for Minimal .dataview.list-view-ul width - Minimal set the width with --line-width-adaptive (40rem by default) */
 	body:not(.table-100):not(.table-max):not(.table-wide) .markdown-preview-view.is-readable-line-width:not(.table-100):not(.table-max):not(.table-wide) div[data-callout="multi-column"].callout .dataview.list-view-ul {width: auto;}
 
+/* === Multi Column Flex "DIV"'s Using Callout === */
+	/* - Still EXPERIMENTAL, different theme approach border and background differently, but 0.16.x seems to align most */
 
-	/* -- Multi Flex. Still EXPERIMENTAL, different theme approach border and background too differently */
-
+	/* adjusted for Obsidian 0.16.x */
 	div[data-callout="multi-column-flex-height"].callout > .callout-title { display: none; }
 	div[data-callout="multi-column-flex-height"].callout > .callout-content { display: contents; }
 	div[data-callout="multi-column-flex-height"].callout
 		{ display: flex; flex-wrap: wrap; gap: var(--callout-gap); background: unset; border: unset; margin: unset; padding: unset; clear: both; }
 
 	div[data-callout="multi-column-flex-height"].callout > .callout-content > *:is(div,ul) {flex: 1 1 var(--callout-min-width); margin: 0; }
-	div[data-callout="multi-column-flex-height"].callout .callout { background: unset; border: unset; box-shadow: unset; }
+	div[data-callout="multi-column-flex-height"].callout .callout { border: unset; box-shadow: unset; }
 	/* need to reintroduce border-left as original callout put border on the parent callout */
-	div[data-callout="multi-column-flex-height"].callout > .callout-content .callout .callout-title { border-left: 4px solid rgba(var(--callout-color)); border-top-left-radius: 3px;}
-	div[data-callout="multi-column-flex-height"].callout > .callout-content .callout .callout-content { margin: 0; border-left: 4px solid rgba(var(--callout-color)); border-bottom-left-radius: 3px; background-color: var(--background-secondary);}
+	div[data-callout="multi-column-flex-height"].callout > .callout-content .callout .callout-title { border-top-left-radius: 3px;}
+	div[data-callout="multi-column-flex-height"].callout > .callout-content .callout .callout-content { margin: 0; border-bottom-left-radius: 3px; height: min-height;}
 
 	 /* "fix" for theme with negative margin & box shadow. Applicable for Prism theme */
 	 div[data-callout="multi-column-flex-height"].callout > .callout-content { margin-top: unset;}
@@ -203,6 +212,7 @@ body{
 
 /* === Blank Container "DIV"'s - can be used with Main Multi-Column layout above === */
 
+	/* "blank-container" - no bg, no border, no title, no nothing */
 	div[data-callout="blank-container"].callout > .callout-title { display: none; }
 	div[data-callout="blank-container"].callout > .callout-content {display: contents;}
 	div[data-callout="blank-container"].callout { border: 0; padding-top: 0; padding-inline: 5px; background: unset; box-shadow: unset; }
@@ -210,9 +220,11 @@ body{
 	/* -- No Margin -- */
 	/* issues still persists
 	   - headers font size not same
+	   - "no-margin" not fully workable in editing view due to wide-page override for Minimal theme
 	*/
 	div[data-callout-metadata*="no-margin"]:is(.cm-callout, .callout.callout, .callout.callout .callout-content) {margin: 0; padding: 0;}
-	/* fix for Shimmering Focus differing font size in callout */
+
+	/* Special Adjustment for Shimmering Focus. Differing font size in callout */
 	div[data-callout="blank-container"] .callout-content :is(p,ul,li) { font-size: unset; line-height: inherit; }
 	div[data-callout="blank-container"] .callout-content :is(li) { margin: unset; }
 
@@ -234,7 +246,8 @@ body{
 	@media (min-width: 750px){
 		div[data-callout-metadata$="large"].callout {width: var(--float-large-width);}
 	}
-	.embedded-backlinks, .markdown-preview-view h2 { clear: both; }
+	/* .markdown-preview-view h2, *//* remove this as it has weird spacing effect */
+	.embedded-backlinks { clear: both; }
 
 	/* fix for blockquote underlap the float layout */
 	.markdown-preview-view :is(blockquote) { overflow-x: auto; } /* fix for blockquote underlap */
@@ -271,3 +284,20 @@ body{
 	.multi-column-list-block {
 		column-width: var(--list-min-width); column-gap: 3rem; column-rule: var(--col-rule-width) solid var(--col-rule-color);
 	}
+
+/* === mc list using tags === */
+	.tag-mcllist { columns: 3; }
+	.tag-mcllist .callout:first-of-type { margin-top: 0; }
+	.tag-mcllist.cm-callout {padding-block: 1em;}
+	.tag-mcllist ul:first-of-type { margin-top: 0; }
+	/* */
+	/* -- MCL Grid, alpha */
+	.tag-mcllist-grid ul:first-child
+		{ display: grid; grid-template-columns: repeat(auto-fit,minmax(10rem,1fr)); padding-left: 0; }
+	.tag-mcllist-grid ul:first-child > li
+		{ margin-inline: 0.2em; padding: 0.3em 0.5em; border: px solid Gray; border-radius: 0.5em;}
+	.tag-mcllist-grid ul:first-child > li > .list-bullet::after {visibility: hidden;}
+
+	/* hide tag in rendered view, dim it in edit mode */
+	div[class*="mcl"] a[href*="#mcl"] {display: none;}
+	span[class*="mcl"]	{background-color: var(--background-secondary) !important; color: gray !important;}

--- a/MCL Multi Column.css
+++ b/MCL Multi Column.css
@@ -1,6 +1,8 @@
 /* === README ===
 	Author: Faiz Khuzaimah / twitter: @faizkhuzaimah / github: https://github.com/efemkay
-	Version: 0.6.0 (updated 2022-09-25). Version number follow overall MCL
+	Version 0.6.1 (updated 2022-10-02). Version number follow overall MCL
+	- fix for footnote with -column-list-block created a <br> tag
+	Version 0.6.0 (updated 2022-09-25)
 	- partial fix for obsidian v 0.16.x
 	Version 0.4.2 (2022-07-14)
 	- fix for callout width become full-width even without Wide Views module
@@ -284,6 +286,9 @@ body{
 	.multi-column-list-block {
 		column-width: var(--list-min-width); column-gap: 3rem; column-rule: var(--col-rule-width) solid var(--col-rule-color);
 	}
+
+	/* Special adjustment for footnotes applied with -colum-list-block -- obsidian creates a <br> tag at the last <li> */
+	.footnotes [class$="-column-list-block"] li:last-of-type br:last-of-type {display: none;}
 
 /* === mc list using tags === */
 	.tag-mcllist { columns: 3; }

--- a/MCL Wide Views.css
+++ b/MCL Wide Views.css
@@ -1,13 +1,10 @@
 /* === README ===
 	Author: Faiz Khuzaimah / twitter: @faizkhuzaimah / github: https://github.com/efemkay
-	Updated: 2022-09-17 (version: 0.5.0)
+	Current Version: 0.6.0 (updated 2022-09-25)
+	- fix to support Obsidian v0.16.x (mostly editing view and global settings)
+	- code cleanup
+	Previous version: 0.5.0 (updated 2022-09-17)
 	- add vault-wide toggle for wide-dataview, wide-table and wide-callout (backlinks still not working). FR #19 on GH.
-	Previous version: 0.4.2 (2022-07-14)
-	- fix for wide-page not affecting callout
-	- fixes for GH issues #9 and #11
-	- adj for Compatibility with Minimal 5.2.9
-	- add features adjustable RLL and narrow page class
-	- add style settings for adj RLL width and toggle whole class
 
 	What is this snippet for?
 	- for any users to use with any theme to complement any missing page/block width control
@@ -73,14 +70,14 @@ settings:
 		description: use `wide-table` in yaml to enable only for selected note/page
 		type: class-toggle
 	-
-		id: wide-backlinks-global
-		title: Enable `wide-backlinks` vault-wide
-		description: use `wide-backlinks` in yaml to enable only for selected note/page
-		type: class-toggle
-	-
 		id: wide-callout-global
 		title: Enable `wide-callout` vault-wide
 		description: use `wide-callout` in yaml to enable only for selected note/page
+		type: class-toggle
+	-
+		id: wide-backlinks-global
+		title: Enable `wide-backlinks` vault-wide
+		description: use `wide-backlinks` in yaml to enable only for selected note/page
 		type: class-toggle
 
     -
@@ -106,19 +103,27 @@ body{
 
 /* === Wide Page === */
 
-	/* Editing View -- set Readable Line Length (RLL) to wide (100%) for any css class with "wide" word in it.
+
+	/* --- Editing View ---
+		- set Readable Line Length (RLL) to wide (100%) for any css class with "wide" word in it.
 		- "width:100%" added for Blue Topaz
 		- .cm-content added to override Mado 11
-		- focus to fix for v0.16.x -- .markdown-source-view.mod-cm6 .cm-sizer */
-	:is(body:not(.max-view-enabled) .mod-root) div[class*="wide-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer,
-	:is(body:not(.max-view-enabled) .mod-root) div[class*="wide-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content,
-	:is(body:not(.max-view-enabled) .mod-root) div[class*="wide-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content > div,
-	div[class*="wide-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .embedded-backlinks,
-	div[class*="wide-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .embedded-backlinks > div
+		- focus to fix for v0.16.x -- .markdown-source-view.mod-cm6 .cm-sizer
+	*/
+
+	/* - WPEV - */
+	/* Main code */
+	/* Set the containers (all relevant levels) to max-width 100%. Applicable to global and per note (cssClass) */
+	/* selector for editing container .cm-sizer */
+	:is(body[class*="wide-"], div[class*="wide-"].markdown-source-view.mod-cm6.is-readable-line-width) .cm-sizer,
+	/* selector for sub containers
+		- .cm-contentContainer, .cm-contentContainer > .cm-content, .cm-contentContainer > .cm-content > div
+		- .embedded-backlinks, .embedded-backlinks > div */
+	:is(body[class*="wide-"]:not(.max-view-enabled), div[class*="wide-"].markdown-source-view.mod-cm6) :is(.cm-contentContainer.cm-contentContainer, .cm-contentContainer.cm-contentContainer > .cm-content, .cm-contentContainer.cm-contentContainer > .cm-content > div, .embedded-backlinks, .embedded-backlinks > div)
 		{ max-width: 100%; width: 98%;}
 
-	/* Editing View -- Special adjustment
-		- for Minimal theme where it has table also set with max-width. but table require separate line because we don't want width: 100% as that would stretch the table
+	/* Special adjustment - for Minimal
+		- it has table also set with max-width. but table require separate line because we don't want width: 100% as that would stretch the table
 		- but for callout, require width: auto */
 	div[class*="wide-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content table { max-width: 100% }
 	div[class*="wide-"].markdown-source-view.mod-cm6.is-readable-line-width .cm-embed-block.cm-callout>.callout { max-width: 100%; width: auto;}
@@ -128,20 +133,24 @@ body{
 	div[class*="wide-page"].markdown-source-view.mod-cm6 .cm-contentContainer > .cm-content > div
 		{margin-left: 20px !important; }
 
-	/* Editing View -- Additional Note
+	/* Additional Note
 		- Yin Yang uses .markdown-source-view.mod-cm6 { width: !important;}. I'm skipping fixes for this until there's user request
 		- added :is(body:not(.max-view-enabled) .mod-root) to accomodate for Shimmering Focus, does not affect other themes */
 
 
-	/* Reading View -- similar to Editing View, set the RLL to 100% for any css class with "wide" word in it
+	/* --- Reading View --- */
+	/* -- similar to Editing View (WPEV), set the RLL to 100% for any css class with "wide" word in it
 		- :is() used for OR between global toggle and "cssClass" in yaml
 		- "width:100%" added for Blue Topaz */
-	:is(.wide-dataview-global, .wide-table-global, .wide-backlinks-global, .wide-callout-global, div.markdown-preview-view:is(.wide-dataview,.wide-table,.wide-backlinks,.wide-callout)) .markdown-preview-sizer.markdown-preview-sizer, /* double-up for specificity */
-	:is(.wide-dataview-global, .wide-table-global, .wide-backlinks-global, .wide-callout-global, div.markdown-preview-view:is(.wide-dataview,.wide-table,.wide-backlinks,.wide-callout)) .markdown-preview-sizer.markdown-preview-sizer > div
+
+	/* - WPRV - */
+	/* Main code */
+	/* Set the containers (all relevant levels) to max-width 100%. Applicable to global and per note (cssClass) */
+	body[class*="wide-"] :is(.markdown-preview-sizer.markdown-preview-sizer, .markdown-preview-sizer.markdown-preview-sizer > div),
+	div[class*="wide-"].markdown-preview-view :is(.markdown-preview-sizer.markdown-preview-sizer, .markdown-preview-sizer.markdown-preview-sizer > div)
 		{ max-width: 100%; margin-inline: auto; width: 100%;}
 
-	/* Reading View -- Special Adjustment
-		- for Minimal theme */
+	/* Special adjustment - for Minimal theme */
 	div[class*="wide-"].markdown-preview-view {padding-inline: 30px;}
 
 	/* special line just for Atom theme -- commented out for now */
@@ -151,40 +160,69 @@ body{
 		{ max-width: 100% !important; } */
 
 
-/* === Wide Dataview, Table & Backlink === */
+/* === Wide Blocks (i.e. Dataview, Table, Callout & Backlink) === */
 
-	/*	Editing View -- set all divs back to normal width (ensuring specificity rule over some theme), then
-		expand to full-width for each selected css class (i.e. wide-dataview, wide-table and wide-backlinks) */
 
-	:is(body:not(.max-view-enabled) .mod-root) div.markdown-source-view.mod-cm6:is(.wide-dataview,.wide-table,.wide-backlinks,.wide-callout) .cm-contentContainer.cm-contentContainer > .cm-content > div,
-	:is(body:not(.max-view-enabled) .mod-root) div.markdown-source-view.mod-cm6:is(.wide-dataview,.wide-table,.wide-backlinks,.wide-callout) .cm-contentContainer.cm-contentContainer > .embedded-backlinks > div
-		{max-width: var(--normal-max-width); margin-inline: auto !important;} /* important for margin needed because app.css:2842 use it */
-	:is(body:not(.max-view-enabled) .mod-root) div[class*="-dataview"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > div > div:is(.cm-preview-code-block),
-	:is(body:not(.max-view-enabled) .mod-root) div[class*="-table"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > div > div:is(.HyperMD-table-row, .cm-table-widget),
-	:is(body:not(.max-view-enabled) .mod-root) div[class*="-callout"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > div > div:is(.cm-callout),
-	:is(body:not(.max-view-enabled) .mod-root) div[class*="-backlinks"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > div:is(.embedded-backlinks) > div
+	/* --- Editing View ---
+	   - For Editing View, the approach is slightly different. After "wide-page" set all max-width to 100%, I adjust the .cm-content > * blocks to normal width and then selectively target blocks for wide width
+	   - must note to ensure specificity rule over some theme), then
+	   - global settings selector need to be separated to ensure it is not conditional to cssClass yaml
+	   - `body[class*="wide-"]` used for global settings, `div[class*="wide-"].markdown-preview-view` used for per note cssClass
+	*/
+
+	/* - WBEV - */
+	/* Main code */
+	/* Generally set all blocks to normal width, no need (yet) for global settings as I didn't adjust it Wide Page above */
+	/* set .cm-sizer > .inline-title to normal width. has to be separated because i don't want margin auto */
+	:is(body:not(.max-view-enabled) .mod-root) div.markdown-source-view.mod-cm6:is(.wide-dataview,.wide-table,.wide-backlinks,.wide-callout) .cm-sizer > .inline-title
+		{ max-width: var(--normal-max-width); }
+	/* set normal width to `.cm-content > div` and `.embedded-links` only (override the WPEV) */
+	:is(body[class*="wide-"]:not(.max-view-enabled), div[class*="wide-"].markdown-source-view.mod-cm6) :is(.cm-contentContainer.cm-contentContainer > .cm-content > div, .cm-sizer > .embedded-backlinks)
+		{ max-width: var(--normal-max-width); margin-inline: auto !important; } /* important for margin needed because app.css:1473 use it for .cm-contentContainer > .cm-content > * */
+	/* selectors to set dataview, table, callout and/or backlinks to wide */
+	:is(body.wide-dataview-global:not(.max-view-enabled) .mod-root .markdown-source-view.mod-cm6, div[class*="-dataview"].markdown-source-view.mod-cm6) .cm-contentContainer.cm-contentContainer > div > div:is(.cm-preview-code-block),
+	:is(body.wide-table-global:not(.max-view-enabled) .mod-root .markdown-source-view.mod-cm6, div[class*="-table"].markdown-source-view.mod-cm6) .cm-contentContainer.cm-contentContainer > div > div:is(.HyperMD-table-row, .cm-table-widget),
+	:is(body.wide-callout-global:not(.max-view-enabled) .mod-root .markdown-source-view.mod-cm6, div[class*="-callout"].markdown-source-view.mod-cm6) .cm-contentContainer.cm-contentContainer > div > div:is(.cm-callout),
+	/* selectors to set backlinks to wide -- not fix yet for 0.16.x */
+	:is(body.wide-backlinks-global:not(.max-view-enabled) .mod-root .markdown-source-view.mod-cm6, div[class*="-backlinks"].markdown-source-view.mod-cm6) .cm-sizer > div:is(.embedded-backlinks)
 		{ max-width: 100%; }
-	:is(body:not(.max-view-enabled) .mod-root) div[class*="-dataview"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > div > div:is(.cm-preview-code-block) > div /* for minimal */
+
+
+	/* Special adjustment - for Minimal */
+	:is(body:not(.max-view-enabled) .mod-root) div[class*="-dataview"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > div > div:is(.cm-preview-code-block) > div
 		{ width: unset;}
 
-	/* Editing View -- Additional Notes
+	/* Additional Notes
 		- Minimal removes inline padding for .markdown-source-view.mod-cm6 .cm-scroller so it is flushed to the very edges (no way to adjust currently)
 		- added :is(body:not(.max-view-enabled) .mod-root) to accomodate for Shimmering Focus, does not affect other themes */
 
 
-	/*	Reading View -- similar to Editing View, set all divs to normal-width and then selected divs to full-width,
-		however, for Reading View, wide-dataview and wide-table will require Contextual Typography plugin
-		- :is() used to couple global toggle with yaml cssClass */
-	:is(.wide-dataview-global, .wide-table-global, .wide-backlinks-global, .wide-callout-global, div.markdown-preview-view:is(.wide-dataview,.wide-table,.wide-backlinks,.wide-callout)) .markdown-preview-sizer.markdown-preview-sizer > div
+	/* --- Reading View ---
+		- Similar to WBEV, the approach is to leverage on WPRV setting all blocks to wide, set `.markdown-preview-sizer > div` to normal and set related block to wide again
+		- For Reading View, wide-dataview and wide-table will require Contextual Typography plugin
+		- :is() used to couple global toggle with yaml cssClass
+		- wide backlinks still cannot be implemented in 0.16.x as the it is located one div deeper than `.markdown-preview-sizer > div` which means I need to do "look-back", achievable only with :has()
+	*/
+
+	/* - WBRV - */
+	/* Main code */
+	/* set the containers to normal width */
+	:is(body[class*="wide-"], div[class*="wide-"].markdown-preview-view) .markdown-preview-sizer.markdown-preview-sizer > div
 		{ max-width: var(--normal-max-width); margin-inline: auto; } /* important is for Atom theme */
+	/* set the related blocks to wide width */
 	:is(body.wide-dataview-global, div[class*="-dataview"].markdown-preview-view) .markdown-preview-sizer.markdown-preview-sizer > div:is(.el-lang-dataview),
-	div[class*="-dataview"].markdown-preview-view .markdown-preview-sizer.markdown-preview-sizer > div:is(.el-lang-dataview) table, /* for minimal */
 	:is(body.wide-table-global, div[class*="-table"].markdown-preview-view) .markdown-preview-sizer.markdown-preview-sizer > div:is(.el-table),
 	:is(body.wide-callout-global, div[class*="-callout"].markdown-preview-view) .markdown-preview-sizer.markdown-preview-sizer > div[data-callout],
+	/* comment out wide backlinks as no possible fix (yet) for 0.16.x due to notes above *//*
 	:is(body.wide-backlinks-global, div[class*="-backlinks"].markdown-preview-view) .markdown-preview-sizer.markdown-preview-sizer > div:is(.embedded-backlinks)
 		{ max-width: 100%; }
+	*/
 
-	/* Reading View -- Additional Notes
+	/* Special adjustment - for Minimal - it also somehow set the table width within dataview block */
+	:is(body.wide-dataview-global, div[class*="-dataview"].markdown-preview-view) .markdown-preview-sizer.markdown-preview-sizer > div:is(.el-lang-dataview) table
+		{ max-width: 100%; }
+
+	/* Additional Notes
 		- .markdown-preview-section is same div as .markdown-preview-sizer
 		- Atom uses !important for .markdown-preview-view.is-readable-line-width .markdown-preview-section {...}
 			- cannot adjust this at the moment without disrupting other theme's layout */
@@ -198,8 +236,14 @@ body{
 /* === Narrow Page === */
 /* cssClass YAML to allow users with disabled RLL to introduce RLL per page/note basis */
 
-	/* Editing View -- set Readable Line Length (RLL) to wide (100%) for any css class with "wide" word in it
-		- "width:100%" added for Blue Topaz / div.cm-content added to override Mado 11 */
+
+	/* --- Editing View ---
+		- Set Readable Line Length (RLL) to wide (100%) for any css class with "wide" word in it
+	*/
+
+	/* - NPEV - */
+	/* Main code */
+	/* set the containers to narrow width. `div.cm-content` added to override Mado 11 */
  	div[class*="narrow-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer,
  	div[class*="narrow-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content,
  	div[class*="narrow-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content > div,
@@ -207,31 +251,41 @@ body{
  	div[class*="narrow-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .embedded-backlinks > div
  		{ max-width: var(--narrow-max-width); margin-inline: auto; }
 
-	/* Editing View -- Special Adjustment */
-	/* - for Minimal theme where it has table also set with max-width. but table require separate line because we don't want margin: auto that would center the table relative to other elements like para */
-	div[class*="narrow-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content table, /* for minimal */
+	/* Special adjustment - for Minimal */
+	/* it has table also set with max-width. but table require separate line because we don't want margin: auto that would center the table relative to other elements like para */
+	div[class*="narrow-"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content table
 		{ max-width: var(--narrow-max-width); }
- 	/* - for Minimal theme but affecting all theme. Minimal apparently uses !important to control margin the adjustment is still safe because for narrow-page you would want margin: auto anyway */
+ 	/* for Minimal theme but affecting all theme. Minimal apparently uses !important to control margin the adjustment is still safe because for narrow-page you would want margin: auto anyway */
 	div[class*="narrow-"].markdown-source-view.mod-cm6:not(.is-readable-line-width) .cm-contentContainer
 		{ margin-inline: auto !important; }
 
 
- 	/* Reading View -- similar to Editing View, set the RLL to 100% for any css class with "wide" word in it.
-		- "width:100%" added for Blue Topaz */
+	/* --- Reading View ---
+		- Similar to Editing View, set the RLL to 100% for any css class with "wide" word in it.
+	*/
+
+	/* - NPRV - */
+	/* Main code */
+ 	/* set the note with cssClass: narrow- to max-width of the narrow width */
  	div[class*="narrow-"].markdown-preview-view .markdown-preview-sizer.markdown-preview-sizer, /* double-up for specificity */
  	div[class*="narrow-"].markdown-preview-view .markdown-preview-sizer.markdown-preview-sizer > div
  		{ max-width: var(--narrow-max-width); margin-inline: auto;}
 
- 	/* Reading View -- Special Adjustment
-		- for Minimal theme */
+ 	/* Special adjustment - for Minimal theme */
  	div[class*="narrow-"].markdown-preview-view {padding-inline: 30px;}
 
 
 /* === Adjustable RLL === */
 /* cssClass toggle to allow users to adjust the RLL via Style Settings */
 
-	/* Editing View -- set Readable Line Length (RLL) to wide (100%) for any css class with "wide" word in it.
-		- "width:100%" added for Blue Topaz / div.cm-content added to override Mado 11 */
+
+	/* --- Editing View ---
+		- Set Readable Line Length (RLL) to wide (100%) for any css class with "wide" word in it.
+	*/
+
+	/* - AREV - */
+	/* Main code */
+	/* set the containers to the custom adj rll width. `div.cm-content` added to override Mado 11 */
     .is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer,
 	.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content,
 	.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content table, /* for minimal */
@@ -240,8 +294,14 @@ body{
 	.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .embedded-backlinks > div
 		{ max-width: var(--adj-rll-max-width); margin-inline: auto; }
 
-	/* Reading View -- similar to Editing View, set the RLL to 100% for any css class with "wide" word in it
-		- "width:100%" added for Blue Topaz */
+
+	/* --- Reading View ---
+		- Similar to Editing View, set the RLL to 100% for any css class with "wide" word in it
+	*/
+
+	/* - ARRV - */
+	/* Main code */
+	/* set the containers to the custom adj rll width */
 	.is-adj-rll .markdown-preview-view .markdown-preview-sizer.markdown-preview-sizer, /* double-up for specificity */
 	.is-adj-rll .markdown-preview-view .markdown-preview-sizer.markdown-preview-sizer > div
 		{ max-width: var(--adj-rll-max-width); margin-inline: auto;}

--- a/MCL Wide Views.css
+++ b/MCL Wide Views.css
@@ -1,10 +1,13 @@
 /* === README ===
-	Author: Faiz Khuzaimah / twitter: @faizkhuzaimah / github: https://github.com/efemkay
-	Current Version: 0.6.0 (updated 2022-09-25)
+	Snippet: MCL Wide Views / Author: Faiz Khuzaimah / twitter: @faizkhuzaimah / github: https://github.com/efemkay
+	Version 0.6.2 (updated 2022-10-22)
+	- update to support Obsidian 1.0.0
+	- Fix wide-page not renderring properly in editing view (conflict with global/vault wide settings
+	- Adjusted the variable for Adjustable RLL to make use of Obsidian default variable --file-line-width. Changes not break the settings as I mapped it to MCL own variable --adj-rll-max-width
+	- Fix for wide-table not renderring properly in editing view for Minimal theme.
+	Version 0.6.0 (updated 2022-09-25)
 	- fix to support Obsidian v0.16.x (mostly editing view and global settings)
 	- code cleanup
-	Previous version: 0.5.0 (updated 2022-09-17)
-	- add vault-wide toggle for wide-dataview, wide-table and wide-callout (backlinks still not working). FR #19 on GH.
 
 	What is this snippet for?
 	- for any users to use with any theme to complement any missing page/block width control
@@ -96,8 +99,8 @@ settings:
 */
 
 body{
-	--normal-max-width: 750px;
-	--narrow-max-width: 750px;
+	--normal-max-width: var(--file-line-width);
+	--narrow-max-width: var(--file-line-width);
 	--adj-rll-max-width: 750px;
 }
 
@@ -132,6 +135,8 @@ body{
 	div[class*="wide-page"].markdown-source-view.mod-cm6 .cm-contentContainer > .embedded-backlinks,
 	div[class*="wide-page"].markdown-source-view.mod-cm6 .cm-contentContainer > .cm-content > div
 		{margin-left: 20px !important; }
+	div[class*="wide-page"].markdown-source-view.mod-cm6.is-readable-line-width table
+		{margin-left: unset !important; }
 
 	/* Additional Note
 		- Yin Yang uses .markdown-source-view.mod-cm6 { width: !important;}. I'm skipping fixes for this until there's user request
@@ -174,11 +179,12 @@ body{
 	/* Main code */
 	/* Generally set all blocks to normal width, no need (yet) for global settings as I didn't adjust it Wide Page above */
 	/* set .cm-sizer > .inline-title to normal width. has to be separated because i don't want margin auto */
-	:is(body:not(.max-view-enabled) .mod-root) div.markdown-source-view.mod-cm6:is(.wide-dataview,.wide-table,.wide-backlinks,.wide-callout) .cm-sizer > .inline-title
-		{ max-width: var(--normal-max-width); }
+	:is(body[class*="wide-"]:not(.max-view-enabled) .mod-root .markdown-source-view.mod-cm6:not(.wide-page), div.markdown-source-view.mod-cm6:is(.wide-dataview,.wide-table,.wide-backlinks,.wide-callout)) .cm-sizer > .inline-title
+		{ max-width: var(--normal-max-width); width: 100%; margin-inline: auto; }
 	/* set normal width to `.cm-content > div` and `.embedded-links` only (override the WPEV) */
-	:is(body[class*="wide-"]:not(.max-view-enabled), div[class*="wide-"].markdown-source-view.mod-cm6) :is(.cm-contentContainer.cm-contentContainer > .cm-content > div, .cm-sizer > .embedded-backlinks)
+	:is(body[class*="wide-"]:not(.max-view-enabled) .markdown-source-view.mod-cm6:not(.wide-page), div[class*="wide-"].markdown-source-view.mod-cm6:not(.wide-page)) :is(.cm-contentContainer.cm-contentContainer > .cm-content > div, .cm-sizer > .embedded-backlinks)
 		{ max-width: var(--normal-max-width); margin-inline: auto !important; } /* important for margin needed because app.css:1473 use it for .cm-contentContainer > .cm-content > * */
+
 	/* selectors to set dataview, table, callout and/or backlinks to wide */
 	:is(body.wide-dataview-global:not(.max-view-enabled) .mod-root .markdown-source-view.mod-cm6, div[class*="-dataview"].markdown-source-view.mod-cm6) .cm-contentContainer.cm-contentContainer > div > div:is(.cm-preview-code-block),
 	:is(body.wide-table-global:not(.max-view-enabled) .mod-root .markdown-source-view.mod-cm6, div[class*="-table"].markdown-source-view.mod-cm6) .cm-contentContainer.cm-contentContainer > div > div:is(.HyperMD-table-row, .cm-table-widget),
@@ -191,6 +197,8 @@ body{
 	/* Special adjustment - for Minimal */
 	:is(body:not(.max-view-enabled) .mod-root) div[class*="-dataview"].markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > div > div:is(.cm-preview-code-block) > div
 		{ width: unset;}
+	/* Special adjustment - for Minimal - to override custom margin-left that uses !important */
+	.wide-table.markdown-source-view.mod-cm6.is-readable-line-width table {margin-left: auto !important; }
 
 	/* Additional Notes
 		- Minimal removes inline padding for .markdown-source-view.mod-cm6 .cm-scroller so it is flushed to the very edges (no way to adjust currently)
@@ -207,7 +215,7 @@ body{
 	/* - WBRV - */
 	/* Main code */
 	/* set the containers to normal width */
-	:is(body[class*="wide-"], div[class*="wide-"].markdown-preview-view) .markdown-preview-sizer.markdown-preview-sizer > div
+	:is(body[class*="wide-"] .markdown-preview-view:not(.wide-page), div[class*="wide-"].markdown-preview-view:not(.wide-page)) .markdown-preview-sizer.markdown-preview-sizer > div
 		{ max-width: var(--normal-max-width); margin-inline: auto; } /* important is for Atom theme */
 	/* set the related blocks to wide width */
 	:is(body.wide-dataview-global, div[class*="-dataview"].markdown-preview-view) .markdown-preview-sizer.markdown-preview-sizer > div:is(.el-lang-dataview),
@@ -221,6 +229,8 @@ body{
 	/* Special adjustment - for Minimal - it also somehow set the table width within dataview block */
 	:is(body.wide-dataview-global, div[class*="-dataview"].markdown-preview-view) .markdown-preview-sizer.markdown-preview-sizer > div:is(.el-lang-dataview) table
 		{ max-width: 100%; }
+	/* Special adjustment - for Minimal - to override Minimal custom width */
+	body[class*="global"].contextual-typography .markdown-preview-view.is-readable-line-width .markdown-preview-sizer > div { width: 100%; }
 
 	/* Additional Notes
 		- .markdown-preview-section is same div as .markdown-preview-sizer
@@ -277,31 +287,36 @@ body{
 
 /* === Adjustable RLL === */
 /* cssClass toggle to allow users to adjust the RLL via Style Settings */
+/* Obsidian v1.0.0 makes it easier to do adjustable RLL -- just single line css ;) */
 
+	/* --- Editing and Reading View --- */
+	/* - AREV and ARRV - */
+	body.is-adj-rll { --file-line-width: var(--adj-rll-max-width); }
 
-	/* --- Editing View ---
-		- Set Readable Line Length (RLL) to wide (100%) for any css class with "wide" word in it.
-	*/
+	/* I still save below snippet for future references. May delete later */
 
-	/* - AREV - */
-	/* Main code */
-	/* set the containers to the custom adj rll width. `div.cm-content` added to override Mado 11 */
-    .is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer,
-	.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content,
-	.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content table, /* for minimal */
-	.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content > div,
-	.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .embedded-backlinks,
-	.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .embedded-backlinks > div
-		{ max-width: var(--adj-rll-max-width); margin-inline: auto; }
+		/* --- Editing View ---
+			- Set Readable Line Length (RLL) to wide (100%) for any css class with "wide" word in it.
+		*/
 
+		/* - AREV - */
+		/* Main code */
+		/* set the containers to the custom adj rll width. `div.cm-content` added to override Mado 11 *//*
+	    .is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer,
+		.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content,
+		.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content table, /* for minimal *//*
+		.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .cm-content > div,
+		.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .embedded-backlinks,
+		.is-adj-rll .markdown-source-view.mod-cm6 .cm-contentContainer.cm-contentContainer > .embedded-backlinks > div
+			{ max-width: var(--adj-rll-max-width); margin-inline: auto; }
 
-	/* --- Reading View ---
-		- Similar to Editing View, set the RLL to 100% for any css class with "wide" word in it
-	*/
+		/* --- Reading View ---
+			- Similar to Editing View, set the RLL to 100% for any css class with "wide" word in it
+		*/
 
-	/* - ARRV - */
-	/* Main code */
-	/* set the containers to the custom adj rll width */
-	.is-adj-rll .markdown-preview-view .markdown-preview-sizer.markdown-preview-sizer, /* double-up for specificity */
-	.is-adj-rll .markdown-preview-view .markdown-preview-sizer.markdown-preview-sizer > div
-		{ max-width: var(--adj-rll-max-width); margin-inline: auto;}
+		/* - ARRV - */
+		/* Main code */
+		/* set the containers to the custom adj rll width *//*
+		.is-adj-rll .markdown-preview-view .markdown-preview-sizer.markdown-preview-sizer, /* double-up for specificity *//*
+		.is-adj-rll .markdown-preview-view .markdown-preview-sizer.markdown-preview-sizer > div
+			{ max-width: var(--adj-rll-max-width); margin-inline: auto;}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Modular CSS Layout for Obsidian.md
-`v0.6.1 updated 2022-10-02` -- beta for Obsidian v0.16.x
-- fix to support Obsidian v0.16.x. Wide Views and Multi Column for now
-- fix for `-column-list-block` in footnotes
+`v0.6.2 updated 2022-10-22` -- Support for Obsidian v1.0.x
 
 This is a repository for modular CSS layout hack for use with [Obsidian.md](https://obsidian.md/). It's meant to complement/assist Community Theme, focusing solely on providing alternative layout to standard width and standard top-bottom block view.
 
+I mainly do casual test on select popular themes like ITS, Primary, Shimmering Focus, Prism, and Minimal. Need your help to let me know if there's anything not working right. Do log in [MCL GH Issue](https://github.com/efemkay/obsidian-modular-css-layout/issues) if you find anything not working properly. 
+
 ### Table of Content
-- [Install/Download](https://github.com/efemkay/obsidian-modular-css-layout#installation--download-and-enable)
-- [Wide Views](https://github.com/efemkay/obsidian-modular-css-layout#wide-views)
-- [Multi Column](https://github.com/efemkay/obsidian-modular-css-layout#multi-column)
-- [Gallery Cards](https://github.com/efemkay/obsidian-modular-css-layout#gallery-cards)
-- [Support Me](https://github.com/efemkay/obsidian-modular-css-layout#support-me)
+- [Install/Download](#installation--download-and-enable)
+- [Wide Views](#wide-views)
+- [Multi Column](#multi-column)
+- [Gallery Cards](#gallery-cards)
+- [Support Me](#support-me)
 
 ## Installation / Download and Enable
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Modular CSS Layout for Obsidian.md
-`v0.6.0 updated 2022-09-25` -- beta for Obsidian v0.16.x
-- fix to support Obsidian v0.16.x. Wide Views and Multi Column for now 
+`v0.6.1 updated 2022-10-02` -- beta for Obsidian v0.16.x
+- fix to support Obsidian v0.16.x. Wide Views and Multi Column for now
+- fix for `-column-list-block` in footnotes
 
 This is a repository for modular CSS layout hack for use with [Obsidian.md](https://obsidian.md/). It's meant to complement/assist Community Theme, focusing solely on providing alternative layout to standard width and standard top-bottom block view.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Modular CSS Layout for Obsidian.md
-`v0.5.0 updated 2022-09-17`
+`v0.6.0 updated 2022-09-25` -- beta for Obsidian v0.16.x
+- fix to support Obsidian v0.16.x. Wide Views and Multi Column for now 
 
 This is a repository for modular CSS layout hack for use with [Obsidian.md](https://obsidian.md/). It's meant to complement/assist Community Theme, focusing solely on providing alternative layout to standard width and standard top-bottom block view.
 


### PR DESCRIPTION
## Features

Wide Views / Multi Column / Gallery Cards
- updated MCL to support Obsidian v1.0.0
	- there will be further refinement in future to further simplify the code by making use of the existing css variables

## Fixes

Wide Views
- Fix `wide-page` not renderring properly in editing view (conflict with global/vault wide settings for dataview/table/callout)
- Adjusted the variable for Adjustable RLL to make use of Obsidian default variable `--file-line-width`. Changes not break the settings as I mapped it to MCL own variable `--adj-rll-max-width`
- Fix for `wide-table` not renderring properly in editing view for Minimal theme.

Multi Column
- (rollover from 0.6.1) Fix multi column using `*-column-list-block` in footnotes create a `<br>`  tag in the last `<li>`