### PR TITLE
Fix typo in Gallery Card

### DIFF
--- a/MCL Gallery Cards.css
+++ b/MCL Gallery Cards.css
@@ -222,7 +222,7 @@
 		position: fixed;
 		background: rgba(0,0,0,0.8)
 	}
-	body.mermaid-zoom:not(.is-mobile) .markdown-source-view. .cm-embed-block:has(.mermaid svg:active) .mermaid { overflow-x: hidden; }
+	body.mermaid-zoom:not(.is-mobile) .markdown-source-view .cm-embed-block:has(.mermaid svg:active) .mermaid { overflow-x: hidden; }
 	body.mermaid-zoom:not(.is-mobile) .markdown-source-view .mermaid svg:active {
 		cursor: zoom-out;
 		position: fixed;


### PR DESCRIPTION
When I deployed this plugin to a Digital Garden, the build produced an error at this point. Removing the extra period fixed the issue and allowed the site to build.